### PR TITLE
TOOLS-2358 joyCommonLabels should let caller override computed pkgsrc_arch

### DIFF
--- a/vars/joyCommonLabels.groovy
+++ b/vars/joyCommonLabels.groovy
@@ -22,9 +22,12 @@ void call(Map args = [:]) {
     args.pi = args.pi ?: '20151126T062538Z';
     args.jenkins_agent = args.jenkins_agent ?: '2';
 
-    String pkgsrc_arch = 'x86_64';
-    if (args.image_ver < '18.4.0') {
-        pkgsrc_arch = 'multiarch';
+    String pkgsrc_arch = args.pkgsrc_arch;
+    if (! pkgsrc_arch) {
+        pkgsrc_arch = 'x86_64';
+        if (args.image_ver < '18.4.0') {
+            pkgsrc_arch = 'multiarch';
+        }
     }
     String labels = "!platform:true && image_ver:${args.image_ver} && pkgsrc_arch:${pkgsrc_arch} && pi:${args.pi} && jenkins_agent:${args.jenkins_agent}";
     echo "joyent common labels computed: ${labels}";


### PR DESCRIPTION
This change allows callers to specify the pkgsrc_arch in case the default isn't sufficient. An alternate implementation might be to just hardcode a check for image_ver 1.6.3, and automatically set pkgsrc_arch to 'i386' (I'm happy to do that instead if you prefer)

I've not been able to test this change yet, so I'd quite like to push it to a branch of jenkins-joylib and see whether the change works before merging this PR, but I don't yet have permissions to do that. Attempts to persuade Jenkins to look at timfoster/jenkins-joylib failed, discussed at https://chat.joyent.us/joyent/pl/u8ndwx6m8iypzbdnupi8gkgnkh
