### PR TITLE
TOOLS-2522: Slack notifications don't send "comment" strings at all.

### DIFF
--- a/vars/joySlackNotifications.groovy
+++ b/vars/joySlackNotifications.groovy
@@ -49,8 +49,7 @@ void call(Map args = [:]) {
         slackSend(
             channel: channel,
             color: "${if (currentBuild.currentResult == 'SUCCESS') 'good' else 'danger'}",
-            message: "${env.JOB_NAME} - #${env.BUILD_NUMBER} ${emoji} ${currentBuild.currentResult} after ${currentBuild.durationString.replace(' and counting', '')} (<${currentBuild.absoluteUrl}|Open>)",
-            text: slackText)
+            message: "${env.JOB_NAME} - #${env.BUILD_NUMBER} ${emoji} ${currentBuild.currentResult} after ${currentBuild.durationString.replace(' and counting', '')} (<${currentBuild.absoluteUrl}|Open>)\n ${slackText}")
     } else {
         echo "[joySlackNotification] not in master, mantav1, or release-YYYYMMDD branch: suppressing notification"
     }


### PR DESCRIPTION
This re-tags 'v1.0.8' FWIW.