### PR TITLE
TOOLS-2582 Slack channels need renaming or not specifying in Jenkinsfiles, post-EdgeCast-move.

### DIFF
--- a/vars/joySlackNotifications.groovy
+++ b/vars/joySlackNotifications.groovy
@@ -4,15 +4,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  * Copyright 2021 Joyent, Inc.
+ * Copyright 2025 MNX Cloud, Inc.
  */
 
 
 /**
- * Notify the jenkins Slack channel, only on master/release branches, and
+ * Notify the cloud-jenkins Slack channel, only on master/release branches, and
  * don't neglect colors or emoji.
 */
 void call(Map args = [:]) {
-    String channel = args.channel ?: 'jenkins';
+    String channel = args.channel ?: 'cloud-jenkins';
     String comment = args.comment ?: '';
 
     // adapted from https://github.com/jenkinsci/slack-plugin/blob/slack-2.48/src/main/java/jenkins/plugins/slack/ActiveNotifier.java


### PR DESCRIPTION
Some questions that must be answered:

- Bump tag to `v1.0.9` (or more drastic?)?

- If NO to #1, should we have remap code for `smartos` ?

