### PR TITLE
TOOLS-2592 Want to ship service images from monitor-reef

### DIFF
--- a/vars/joyBuildImageAndUpload.groovy
+++ b/vars/joyBuildImageAndUpload.groovy
@@ -4,18 +4,35 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2026 Edgecast Cloud LLC.
  */
 
 
 /**
  * Invokes multiple engbld targets to both build and image, and upload it to an
  * image server.
+ *
+ * Optional parameters:
+ *   dir: directory to run make from (for monorepos that produce multiple
+ *        images). When unset, make runs from the current working directory
+ *        (typically the workspace root).
+ *
+ * Example: joyBuildImageAndUpload(dir: 'mysubdir')
  */
-void call() {
-    sh('''
+void call(Map args = [:]) {
+    Set unknownArgs = args.keySet() - ['dir'] as Set;
+    if (unknownArgs) {
+        error("joyBuildImageAndUpload: unknown parameter(s): " +
+              "${unknownArgs}. Valid parameters are: dir.")
+    }
+    String makeDir = args.dir ?: '.';
+    echo "[joyBuildImageAndUpload] building from directory: ${makeDir}"
+    withEnv(["MAKE_DIR=${makeDir}"]) {
+        sh('''
 set -o errexit
 set -o pipefail
 
 export ENGBLD_BITS_UPLOAD_IMGAPI=true
-make print-BRANCH print-STAMP all release publish buildimage bits-upload''')
+make -C "$MAKE_DIR" print-BRANCH print-STAMP all release publish buildimage bits-upload''')
+    }
 }


### PR DESCRIPTION
Add optional dir parameter to joyBuildImageAndUpload for monorepo support

Allow callers to specify a subdirectory for make via `dir:` parameter, enabling monorepos that produce multiple images. Includes unknown-parameter validation, diagnostic logging, and updated documentation.